### PR TITLE
Fix commonjs build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,14 @@
 {
+  "env": {
+    "cjs": {
+      "presets": [
+        "env",
+        "stage-3",
+        "react"
+      ],
+      "plugins": []
+    }
+  },
   "presets": [
     ["env", {
       "modules": false


### PR DESCRIPTION
Files under `lib/` use ES modules instead of commonjs. This is a simple fix, but I can later simplify the whole build process if you want.

Also should I add tests for this?  