### PR TITLE
Add support for injecting a custom argument into epics

### DIFF
--- a/src/combineEpics.js
+++ b/src/combineEpics.js
@@ -1,7 +1,7 @@
 import { mergeArray } from 'most'
 import { findIndex, map } from '@most/prelude'
 
-export const combineEpics = epicsArray => (actions, store) => {
+export const combineEpics = epicsArray => (actions, store, dependencies) => {
   if (!epicsArray || !Array.isArray(epicsArray)) {
     throw new TypeError('You must provide an array of Epics to combineEpics.')
   }
@@ -15,7 +15,7 @@ export const combineEpics = epicsArray => (actions, store) => {
       throw new TypeError('The array passed to combineEpics must contain only Epics (functions).')
     }
 
-    const out = epic(actions, store)
+    const out = epic(actions, store, dependencies)
 
     if (!out || !out.source) {
       const epicIdentifier = epic.name

--- a/src/createEpicMiddleware.js
+++ b/src/createEpicMiddleware.js
@@ -3,7 +3,7 @@ import { async } from 'most-subject'
 import { epicBegin, epicEnd } from './actions'
 import { STATE_STREAM_SYMBOL } from './constants'
 
-export const createEpicMiddleware = epic => {
+export const createEpicMiddleware = (epic, dependencies) => {
   if (typeof epic !== 'function') {
     throw new TypeError('You must provide an Epic (a function) to createEpicMiddleware.')
   }
@@ -33,9 +33,9 @@ export const createEpicMiddleware = epic => {
 
         return isUsingStateStreamEnhancer
           // new style API (declarative only, no dispatch/getState)
-          ? nextEpic(actionsIn$, state$)
+          ? nextEpic(actionsIn$, state$, dependencies)
           // redux-observable style Epic API
-          : nextEpic(actionsIn$, middlewareApi)
+          : nextEpic(actionsIn$, middlewareApi, dependencies)
       }
 
       const actionsOut$ = switchLatest(map(callNextEpic, epic$))

--- a/tests/combineEpics.test.js
+++ b/tests/combineEpics.test.js
@@ -9,14 +9,15 @@ test('combineEpics should combine an array of epics', t => {
   const DELEGATED_1 = 'DELEGATED_1'
   const DELEGATED_2 = 'DELEGATED_2'
   const MOCKED_STORE = { I: 'am', a: 'store' }
+  const DEPENDENCIES = 'deps'
 
   const epic1 = (actions$, store) => map(
     action => ({ type: DELEGATED_1, action, store }),
     select(ACTION_1, actions$)
   )
 
-  const epic2 = (actions$, store) => map(
-    action => ({ type: DELEGATED_2, action, store }),
+  const epic2 = (actions$, store, deps) => map(
+    action => ({ type: DELEGATED_2, action, store, deps }),
     select(ACTION_2, actions$)
   )
 
@@ -27,7 +28,7 @@ test('combineEpics should combine an array of epics', t => {
 
   const store = MOCKED_STORE
   const actions$ = sync()
-  const result$ = epic(actions$, store)
+  const result$ = epic(actions$, store, DEPENDENCIES)
   const emittedActions = []
 
   observe(emittedAction => emittedActions.push(emittedAction), result$)
@@ -37,7 +38,7 @@ test('combineEpics should combine an array of epics', t => {
 
   const MOCKED_EMITTED_ACTIONS = [
     { type: DELEGATED_1, action: { type: ACTION_1 }, store },
-    { type: DELEGATED_2, action: { type: ACTION_2 }, store },
+    { type: DELEGATED_2, action: { type: ACTION_2 }, store, deps: DEPENDENCIES },
   ]
 
   t.deepEqual(MOCKED_EMITTED_ACTIONS, emittedActions)


### PR DESCRIPTION
Hi, after using the project for a bit I'm really missing the dependency injection from thunk and redux-observable for my testing.

Implementing this was raised in issue #19 but dismissed at the time in favour of a more elegant HOF approach and imminent API changes, but after four months with no project activity I've gone for the simplest, most pragmatic implementation that I believe is backwards-compatible.

If you're willing to accept this (until the lovely proposed HOF-support rewrite arrives) let me know and I'll update the documentation too.