### PR TITLE
fix: avoid typescript error for 3.4+

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ export interface DefaultAction extends Action<ActionType> {
 // for the original, redux-observable style API
 export type OriginalApiEpic<S, A extends Action = DefaultAction> = (
   actionStream: Stream<A>,
-  middlewareApi: MiddlewareAPI<Dispatch<A>, S>,
+  middlewareApi: MiddlewareAPI<Dispatch<DefaultAction>, S>,
 ) => Stream<A>
 
 // for the newer, declarative only API, which takes in a state stream


### PR DESCRIPTION
typescript was getting grumpy about calling `Dispatch` with `Action` type, I'm not entirely sure why, but passing it `DefaultAction` (which is the equivalent of `AnyAction`) appeases it

could this be merged asap as it's blocking us upgrading to the latest version of typescript :smile: 

https://github.com/joshburgess/redux-most/issues/34